### PR TITLE
Add table styles, fixes WP-API/WP-API.github.io#29

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -87,6 +87,7 @@ table {
   border-collapse: separate;
   border-spacing: 0;
   vertical-align: middle;
+  margin: 1em 0px;
 }
 caption,
 th,
@@ -94,6 +95,30 @@ td {
   text-align: left;
   font-weight: normal;
   vertical-align: middle;
+}
+th, 
+td {
+  border-right: 1px solid rgba(0, 0, 0, 0.0666667);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.0666667);
+  text-align: center;
+}
+th {
+  font-weight: bold;
+  padding: 0.2em 0.5em;
+  border-top: 1px solid rgba(0, 0, 0, 0.0666667);
+}
+td {
+  padding: 0.4em;
+}
+th:first-child, 
+td:first-child {
+  padding-left: 0px;
+  text-align: left;
+}
+th:last-child, 
+td:last-child {
+  padding-right: 0px;
+  border-right: none;
 }
 a img {
   border: none;


### PR DESCRIPTION
Basic table style to improve the table styling on http://wp-api.org/misc/comparison.html

Looks something like this, if you can remove the inline styles. Otherwise there would be a need for `!important` to center the features `X|~|P`.

![screenshot 2015-02-09 22 41 23](https://cloud.githubusercontent.com/assets/368120/6116952/1383abd4-b0b1-11e4-9862-92d96d71762e.png)
